### PR TITLE
Update apt package pins to current noble versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,7 +57,7 @@
       ],
       "versioningTemplate": "deb",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "ubuntu_22_04/{{package}}"
+      "depNameTemplate": "ubuntu_24_04/{{package}}"
     }
   ],
   "packageRules": [

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -32,11 +32,11 @@ RUN \
     apt-get update \
     \
     && apt-get install -y --no-install-recommends \
-        ca-certificates=20240203 \
-        curl=8.5.0-2ubuntu10.6 \
-        jq=1.7.1-3ubuntu0.24.04.1 \
-        tzdata=2025b-0ubuntu0.24.04.1 \
-        xz-utils=5.6.1+really5.4.5-1 \
+        ca-certificates=20260601~24.04.1 \
+        curl=8.5.0-2ubuntu10.13 \
+        jq=1.7.1-3ubuntu0.24.04.2 \
+        tzdata=2026c-0ubuntu0.24.04.1 \
+        xz-utils=5.6.1+really5.4.5-1ubuntu0.3 \
     \
     && S6_ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "amd64" ]; then S6_ARCH="x86_64"; fi \


### PR DESCRIPTION
# Proposed Changes

The pinned versions of `curl`, `jq` and `tzdata` are no longer available in the Ubuntu noble repositories (they have been superseded by newer security updates), which causes `apt-get install` to fail with exit code 100. This breaks the build on `main` and, as a result, on every currently open pull request (#178, #179, #180, #181).

This PR updates all apt pins to the versions currently available in noble for both `amd64` and `aarch64`:

| Package | Before | After |
| --- | --- | --- |
| `ca-certificates` | `20240203` | `20260601~24.04.1` |
| `curl` | `8.5.0-2ubuntu10.6` | `8.5.0-2ubuntu10.13` |
| `jq` | `1.7.1-3ubuntu0.24.04.1` | `1.7.1-3ubuntu0.24.04.2` |
| `tzdata` | `2025b-0ubuntu0.24.04.1` | `2026c-0ubuntu0.24.04.1` |
| `xz-utils` | `5.6.1+really5.4.5-1` | `5.6.1+really5.4.5-1ubuntu0.3` |

The old `ca-certificates` and `xz-utils` pins still installed (they remain in the release pocket), but a base image should carry the security updates, so those are bumped as well.

Additionally, the Renovate repology manager is pointed at `ubuntu_24_04` instead of `ubuntu_22_04`, matching the noble base image this repository actually builds from.

Both architectures were built and smoke tested locally (`curl`, `jq`, `tempio` and `/init` all present and working).

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Unblocks #178, #179, #180 and #181.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build environment to use newer Ubuntu 24.04 package sources.
  - Refreshed several foundational system packages, including certificate, networking, timezone, and archive-handling components.
  - These maintenance updates keep packaged application environments aligned with current Ubuntu releases and recent patch levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->