### PR TITLE
Track Ubuntu apt pins with the Renovate deb datasource

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,8 +57,8 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
       ],
       "versioningTemplate": "deb",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "ubuntu_26_04/{{package}}"
+      "datasourceTemplate": "deb",
+      "depNameTemplate": "{{{package}}}"
     }
   ],
   "packageRules": [
@@ -69,7 +69,12 @@
       "automerge": true
     },
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["deb"],
+      "registryUrls": [
+        "https://archive.ubuntu.com/ubuntu?suite=resolute&components=main&binaryArch=amd64",
+        "https://archive.ubuntu.com/ubuntu?suite=resolute-updates&components=main&binaryArch=amd64",
+        "https://security.ubuntu.com/ubuntu?suite=resolute-security&components=main&binaryArch=amd64"
+      ],
       "automerge": true
     },
     {


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Repology has become unreliable as a datasource lately: throttling, timeouts, and missing packages. For Ubuntu it has an additional problem: it only tracks the upstream version (e.g. `8.18.0` for `curl`), not the Ubuntu revision (`8.18.0-1ubuntu2.5`), so it never proposed the security pocket updates that our apt pins actually need. That is how `main` ended up with pins that no longer existed in the archive (#183 / #178).

Renovate ships a native [`deb` datasource](https://docs.renovatebot.com/modules/datasource/deb/) that reads the package indices directly, so this switches the apt pins over to it, the same way as done in hassio-addons/app-vaultwarden#447 for the Debian based apps. It indexes binary package names, so `depNameTemplate` becomes plain `{{{package}}}`.

The registry URLs mirror the apt sources of the `ubuntu:resolute` image, limited to the `main` component, which is where all pinned packages live:

| Source | Suite | Component |
| --- | --- | --- |
| `archive.ubuntu.com/ubuntu` | `resolute` | `main` |
| `archive.ubuntu.com/ubuntu` | `resolute-updates` | `main` |
| `security.ubuntu.com/ubuntu` | `resolute-security` | `main` |

The `deb` datasource uses a `merge` registry strategy, so releases from all three pockets are aggregated. `resolute-backports` is deliberately left out: apt does not install from it unless asked, and including it would make Renovate propose backported versions. The `universe` component (20 MB index) is left out as well since nothing pinned lives there; it can be added to `components` should a future pin need it.

Unlike the Debian archive, the Ubuntu archive serves `Packages.gz` for every pocket, so the hardcoded `Packages.gz` limitation of the datasource (renovatebot/renovate#44330) does not apply here and all three pockets work today.

Validated with `renovate-config-validator` from Renovate 44.82.4, and with a local `renovate --platform=local --dry-run=lookup` run: all five current pins resolve as up to date from the three pockets, and with `curl` and `tzdata` temporarily lowered to their release pocket versions, Renovate correctly proposed `8.18.0-1ubuntu2.5` and `2026c-0ubuntu0.26.04.1` from the updates/security pockets.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Same change as hassio-addons/app-vaultwarden#447.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Debian package update tracking to use Ubuntu’s archive, updates, and security repositories for the Resolute amd64 suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->